### PR TITLE
Adding Port Compatibility for the Printers + Added TM88IV to list of tested Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _Disclaimer: This was vibe coded. It's a very straightforward and scoped compone
 4. Enter the following information:
    - **Printer Name**: A friendly name for your printer (e.g., "Kitchen Receipt Printer")
    - **Printer IP Address**: The IP address of your receipt printer on your network
+   - **Printer Port**: The Port of the Printer (default: 9100)
    - **Columns (Font A)**: Number of text columns for font A (default: 42, suitable for TM-T88V)
    - **Columns (Font B)**: Number of text columns for font B (default: 56, suitable for TM-T88V)
    - **Image Max Width**: Maximum image width in pixels (default: 512, suitable for TM-T88V)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This integration uses the [python-escpos](https://github.com/python-escpos/pytho
 
 Tested models:
 - Epson TM-T88VI
+- Epson TM-T88IV
 
 Other ESC/POS compatible printers should work but may require adjusting the column widths and image size settings during configuration.
 

--- a/custom_components/receipt_printer/api.py
+++ b/custom_components/receipt_printer/api.py
@@ -31,6 +31,7 @@ class ReceiptPrinterApiClient:
     def __init__(
         self,
         host: str,
+        port: int = 9100,
         columns_font_a: int = 42,
         columns_font_b: int = 56,
         image_max_width: int = 512,
@@ -38,6 +39,7 @@ class ReceiptPrinterApiClient:
         """Initialize the Receipt Printer API Client."""
         self._host = host
         self._printer: Network | None = None
+        self._port = port
         self._columns_font_a = columns_font_a
         self._columns_font_b = columns_font_b
         self._image_max_width = image_max_width
@@ -45,7 +47,7 @@ class ReceiptPrinterApiClient:
     def _get_printer(self) -> Network:
         """Get or create printer instance."""
         if self._printer is None:
-            self._printer = Network(self._host)
+            self._printer = Network(self._host, port=self._port)
         return self._printer
 
     async def async_connect(self) -> None:

--- a/custom_components/receipt_printer/config_flow.py
+++ b/custom_components/receipt_printer/config_flow.py
@@ -88,10 +88,13 @@ class ReceiptPrinterFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required{
                         CONF_PRINTER_PORT,
                         default=(user_input or {}).get(CONF_PRINTER_PORT, 9100),
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.TEXT,
-                        },
-                    },
+                        selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=1,
+                                mmax=9999
+                                mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
                     vol.Optional(
                         CONF_COLUMNS_FONT_A,
                         default=(user_input or {}).get(CONF_COLUMNS_FONT_A, 42),

--- a/custom_components/receipt_printer/config_flow.py
+++ b/custom_components/receipt_printer/config_flow.py
@@ -88,10 +88,10 @@ class ReceiptPrinterFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required{
                         CONF_PRINTER_PORT,
                         default=(user_input or {}).get(CONF_PRINTER_PORT, 9100),
-                        selector.NumberSelector(
+                    ): selector.NumberSelector(
                             selector.NumberSelectorConfig(
                                 min=1,
-                                mmax=9999
+                                mmax=9999,
                                 mode=selector.NumberSelectorMode.BOX,
                         ),
                     ),

--- a/custom_components/receipt_printer/config_flow.py
+++ b/custom_components/receipt_printer/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_COLUMNS_FONT_B,
     CONF_IMAGE_MAX_WIDTH,
     CONF_PRINTER_IP,
+    CONF_PRINTER_PORT,
     CONF_PRINTER_NAME,
     DOMAIN,
     LOGGER,
@@ -84,6 +85,13 @@ class ReceiptPrinterFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                             type=selector.TextSelectorType.TEXT,
                         ),
                     ),
+                    vol.Required{
+                        CONF_PRINTER_PORT,
+                        default=(user_input or {}).get(CONF_PRINTER_PORT, 9100),
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT,
+                        },
+                    },
                     vol.Optional(
                         CONF_COLUMNS_FONT_A,
                         default=(user_input or {}).get(CONF_COLUMNS_FONT_A, 42),

--- a/custom_components/receipt_printer/const.py
+++ b/custom_components/receipt_printer/const.py
@@ -8,6 +8,7 @@ DOMAIN = "receipt_printer"
 
 # Config flow
 CONF_PRINTER_IP = "printer_ip"
+CONF_PRINTER_PORT = "printer_port"
 CONF_PRINTER_NAME = "printer_name"
 CONF_COLUMNS_FONT_A = "columns_font_a"
 CONF_COLUMNS_FONT_B = "columns_font_b"

--- a/custom_components/receipt_printer/strings.json
+++ b/custom_components/receipt_printer/strings.json
@@ -6,6 +6,7 @@
                 "data": {
                     "printer_name": "Printer Name",
                     "printer_ip": "Printer IP Address",
+                    "printer_port":"Port",
                     "columns_font_a": "Columns (Font A)",
                     "columns_font_b": "Columns (Font B)",
                     "image_max_width": "Image Max Width (pixels)"


### PR DESCRIPTION
I updated all files to include the Port as an Integer, so everyone can use which ever port they prefer.
Tested this on my slightly modded TM88IV (That is why I needed the different Port in the first place).

I think there is an Issue/Feature request for this as well. 